### PR TITLE
Document how to track back to charva

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ mvn clean package
 java -Djava.awt.headless=true -jar ./charva-demo-app/target/charva-demo.jar
 ```
 ![](https://github.com/viktor-podzigun/charva-lanterna/blob/master/charva-demo-app/doc/screenshot.png)
+
+### How to track the beginning of charva-lanterna back to CHARVA UI
+
+As of 20th March 2016, the original repository of [CHARVA
+UI](http://sourceforge.net/projects/charva/) hosts two branches:
+
+* `trunk` r95 - last updated in 2007. A copy of that branch is stored
+  in `refs/tags/sourceforge-svn-trunk-r95`;
+
+* Branch `andxor` r116 - last updated in 2009. A copy of that branch
+  is stored in tag `refs/tags/sourceforge-svn-branch-andxor-r116`.
+
+charva-lanterna started in 2015, importing a modified version of
+CHARVA UI `trunk` r95 - see charva-lanterna commit f5d7b75 `Added
+charva, charva-showcase, charva-lanterna modules`.  In order to enrich
+the charva-lanterna repository history with CHARVA UI's one, you can
+use `git replace`:
+```bash
+git checkout refs/tags/sourceforge-svn-trunk-r95
+git cherry-pick $(git rev-list master | tail -1)
+git replace $(git rev-list master | tail -1) HEAD
+```


### PR DESCRIPTION
I noticed the project had a big dump at f5d7b75 - basically the whole charva from sourcefourge with modifications e.g. files moved in separate subfolders, files deleted (which? why?), java `import` made more specific, others???. Is the history of that code stored somewhere?

I propose you make it easier to track the project back to CHARVA UI, performing the following actions:
- Please import https://github.com/lucafavatella/charva-lanterna/tree/sourceforge-svn-trunk-r95 as a tag named in the same way;
- Please import https://github.com/lucafavatella/charva-lanterna/tree/sourceforge-svn-branch-andxor-r116 as a tag named in the same way;
- Please review the new content of README.md. **The README depends on the tags creation hence merging the pull request is not enough.**

Notes:
- An alternative would be to rebase master off https://github.com/lucafavatella/charva-lanterna/tree/sourceforge-svn-trunk-r95 but that looks an ugly solution;
- Branch andxor has some changes (e.g. additional awt/swing classes) that might be relevant keeping in mind in case of need.
